### PR TITLE
Travis pypy33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 
 python:
-  - py27
-  - py33
-  - py34
+  - 2.7
+  - 3.3
+  - 3.4
   - pypy
   - pypy3.3-5.2-alpha1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: python
 
-env:
-  # Keep this list up to date using `tox -l`
-  matrix:
-    - TOXENV=py27-django18
-    - TOXENV=py33-django18
-    - TOXENV=py34-django18
-    - TOXENV=pypy-django18
-    - TOXENV=pypy3-django18
-    - TOXENV=flake8
-    - TOXENV=docs
+python:
+  - py27
+  - py33
+  - py34
+  - pypy
+  - pypy3.3-5.2-alpha1
 
-install: travis_retry pip install tox coveralls
+install: travis_retry pip install tox-travis coveralls
 
-script: tox -e $TOXENV
+script: tox
 
 after_success: coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
-    py{27,33,34,py,py3}-django18,
-    flake8,
-    docs
+    py34-{docs,flake8},
+    py{27,33,34,py,py3}-django18
 
 [testenv]
 deps =
@@ -14,12 +13,12 @@ deps =
 commands =
     coverage run -a runtests.py password_validation/test --tb short
 
-[testenv:flake8]
+[testenv:py34-flake8]
 deps = flake8
 changedir = {toxinidir}
 commands = flake8 .
 
-[testenv:docs]
+[testenv:py34-docs]
 deps = Sphinx
 changedir = {toxinidir}/doc
 commands =


### PR DESCRIPTION
@orcasgit/orcas-developers :eyes: This simplifies test matrix management with `tox-travis` and updates the pypy3 used on travis to be one that pip works with